### PR TITLE
Change Message type to use `value` for parsed messages and `data` for raw bytes

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -5,11 +5,9 @@ env:
 ignorePatterns:
   - dist
 
-plugins:
-  - jest
-
 extends:
   - plugin:@foxglove/base
+  - plugin:@foxglove/jest
 
 overrides:
   - files: ["*.ts", "*.tsx"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: main
-    tags: v*
+    branches: [main]
+    tags: ["v*"]
   pull_request:
-    branches: "*"
+    branches: ["*"]
 
 jobs:
   push:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Foxglove
+Copyright Foxglove Technologies Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/MessageIterator.ts
+++ b/src/MessageIterator.ts
@@ -29,15 +29,12 @@ export class MessageIterator implements AsyncIterableIterator<Message> {
       }
 
       const rawMessage = res.value;
+      const { topic, timestamp, data } = rawMessage;
       if (this.decoder == undefined) {
-        return { value: rawMessage, done: false };
+        return { value: { topic, timestamp, data, value: undefined }, done: false };
       }
 
-      const value: Message = {
-        topic: rawMessage.topic,
-        timestamp: rawMessage.timestamp,
-        data: this.decoder(rawMessage),
-      };
+      const value: Message = { topic, timestamp, data, value: this.decoder(rawMessage) };
       return { value, done: false };
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,8 @@ export enum QosPolicyReliability {
 export type Message = {
   topic: Readonly<TopicDefinition>;
   timestamp: Time;
-  data: unknown;
+  data: Uint8Array;
+  value: unknown;
 };
 
 export type MessageReadOptions = {


### PR DESCRIPTION
This allows consumers of parsed messages to access the underlying raw bytes as well. It is a breaking change to the API since the `data` field is now `value` and `data` holds a Uint8Array instead.