### PR TITLE
Add @foxglove/rosmsg-msgs-foxglove to known message definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@foxglove/rosmsg-msgs-common": "^1.0.4",
+    "@foxglove/rosmsg-msgs-foxglove": "^2.0.3",
     "@foxglove/rosmsg2-serialization": "^1.0.5",
     "@foxglove/rostime": "^1.1.1",
     "js-yaml": "^4.1.0"

--- a/src/Rosbag2.ts
+++ b/src/Rosbag2.ts
@@ -1,5 +1,6 @@
 import type { RosMsgDefinition } from "@foxglove/rosmsg";
-import { definitions } from "@foxglove/rosmsg-msgs-common";
+import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
+import { definitions as foxgloveDefs } from "@foxglove/rosmsg-msgs-foxglove";
 import { MessageReader } from "@foxglove/rosmsg2-serialization";
 import { Time, isLessThan as isTimeLessThan } from "@foxglove/rostime";
 
@@ -10,7 +11,7 @@ export const ROS2_TO_DEFINITIONS = new Map<string, RosMsgDefinition>();
 export const ROS2_DEFINITIONS_ARRAY: RosMsgDefinition[] = [];
 
 // New ROS2 header message definition
-definitions["std_msgs/Header"] = {
+commonDefs["std_msgs/Header"] = {
   name: "std_msgs/Header",
   definitions: [
     { type: "time", isArray: false, name: "stamp", isComplex: false },
@@ -19,11 +20,19 @@ definitions["std_msgs/Header"] = {
 };
 
 // Handle the datatype naming difference used in rosbag2 (but not the .msg files)
-for (const ros1Datatype in definitions) {
+for (const ros1Datatype in commonDefs) {
   const ros2Datatype = ros1Datatype.replace("_msgs/", "_msgs/msg/");
-  const msgdef = (definitions as Record<string, RosMsgDefinition>)[ros1Datatype]!;
+  const msgdef = (commonDefs as Record<string, RosMsgDefinition>)[ros1Datatype]!;
   ROS2_DEFINITIONS_ARRAY.push(msgdef);
   ROS2_TO_DEFINITIONS.set(ros2Datatype, msgdef);
+}
+for (const ros1Datatype in foxgloveDefs) {
+  const ros2Datatype = ros1Datatype.replace("_msgs/", "_msgs/msg/");
+  if (!ROS2_TO_DEFINITIONS.has(ros2Datatype)) {
+    const msgdef = (foxgloveDefs as Record<string, RosMsgDefinition>)[ros1Datatype]!;
+    ROS2_DEFINITIONS_ARRAY.push(msgdef);
+    ROS2_TO_DEFINITIONS.set(ros2Datatype, msgdef);
+  }
 }
 
 // New ROS2 log message definition

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,6 +341,13 @@
   dependencies:
     "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
 
+"@foxglove/rosmsg-msgs-foxglove@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@foxglove/rosmsg-msgs-foxglove/-/rosmsg-msgs-foxglove-2.0.3.tgz#53c248f5203c7f748c3e7507504071ca4058d1a6"
+  integrity sha512-4YHSwazNLqjl84oc46ieoF3m0PQGcDtvQp4wGeyDD9X1//zvkK3Bb4mgnV0LC2U8OdBYiNQQy4eQaVnfVc5t8A==
+  dependencies:
+    "@foxglove/rosmsg" "^2.0.0 || ^3.0.0"
+
 "@foxglove/rosmsg2-serialization@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@foxglove/rosmsg2-serialization/-/rosmsg2-serialization-1.0.5.tgz#a0c4954c43ef5a9a2012e57be94e5f3a65d0a35f"


### PR DESCRIPTION
rosbag2 files do not (currently) contain message definitions like rosbag1 files. We work around this in a limited fashion by including well-known ROS message definitions in this library. This expands the list of well-known message definitions to include the Foxglove messages such as `ImageMarkerArray`.