### PR TITLE
Bump @foxglove/schemas to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@foxglove/rosmsg-msgs-common": "^3.0.0",
     "@foxglove/rosmsg2-serialization": "^2.0.0",
     "@foxglove/rostime": "^1.1.2",
-    "@foxglove/schemas": "^1.1.0",
+    "@foxglove/schemas": "^1.3.1",
     "js-yaml": "^4.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,10 +570,10 @@
   resolved "https://registry.yarnpkg.com/@foxglove/rostime/-/rostime-1.1.2.tgz#f8e1f10bff115c22be8a3e06791c2ac800449ee8"
   integrity sha512-vWuTJCuGv0xvgwOlrZ1y2MevmNMVxWcUU/HwlmYXi/jUq/kRaACStU18uyuZ3LzdNKaffkti0rTcXWESaQjwQw==
 
-"@foxglove/schemas@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/schemas/-/schemas-1.1.0.tgz#d3080995a8ba596630d33572c746a19fe4513319"
-  integrity sha512-ojkDY1C/jTCvuh7ctm0jyhdIRlOL0R0jCsISeCw2/U9VzuF/AQtZfLZKDEOfAIa/MVnt3EQVHhOb3oaWetXMzA==
+"@foxglove/schemas@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@foxglove/schemas/-/schemas-1.3.1.tgz#593864face787a4366f0bc363d5ff529e6fd02b4"
+  integrity sha512-YheGkK9eHCeSLCcwjiKwHjWBqwaVlp7opJ+QogMGVqXsSoBs0RrOLlAGVDeL605X2lACClB5gW3FmnllC5vykg==
   dependencies:
     "@foxglove/rosmsg-msgs-common" "^3.0.0"
     tslib "^2.5.0"


### PR DESCRIPTION
### Public-Facing Changes

Bump @foxglove/schemas to 1.3.1

### Description
Bumps `@foxglove/schemas` to 1.3.1 which includes https://github.com/foxglove/schemas/commit/4cea813314a802cd769b0edcb7f99ac26eb921d2. 
